### PR TITLE
Added support for Laravel 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
     "require": {
         "php": ">=7.0",
         "alymosul/exponent-server-sdk-php": "1.1.*",
-        "illuminate/config": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
-        "illuminate/notifications": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
-        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
-        "illuminate/events": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
-        "illuminate/queue": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
-        "illuminate/http": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
-        "illuminate/routing": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
-        "illuminate/validation": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
-        "illuminate/auth": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*"
+        "illuminate/config": "5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
+        "illuminate/notifications": "5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
+        "illuminate/support": "5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
+        "illuminate/events": "5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
+        "illuminate/queue": "5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
+        "illuminate/http": "5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
+        "illuminate/routing": "5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
+        "illuminate/validation": "5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
+        "illuminate/auth": "5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",

--- a/src/ExpoChannel.php
+++ b/src/ExpoChannel.php
@@ -55,7 +55,7 @@ class ExpoChannel
                 true
             );
         } catch (ExpoException $e) {
-            $this->events->fire(
+            $this->events->dispatch(
                 new NotificationFailed($notifiable, $notification, 'expo-push-notifications', $e->getMessage())
             );
         }

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -82,7 +82,7 @@ class ChannelTest extends TestCase
 
         $this->expo->shouldReceive('notify')->with('interest_name', $data, true)->andThrow(ExpoException::class, '');
 
-        $this->events->shouldReceive('fire')->with(Mockery::type(NotificationFailed::class));
+        $this->events->shouldReceive('dispatch')->with(Mockery::type(NotificationFailed::class));
 
         $this->channel->send($this->notifiable, $this->notification);
     }


### PR DESCRIPTION
`fire` method on Illuminate\Events\Dispatcher is an alias of `dispatch` method since Laravel 5.4. `fire` method has been removed since Laravel 5.8 and the Illuminate\Contracts\Events\Dispatcher interface only defines `dispatch` method