### PR TITLE
Fix bug where notifications are not being received in Android

### DIFF
--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -211,11 +211,12 @@ class ExpoMessage
             'sound'     =>  $this->sound,
             'badge'     =>  $this->badge,
             'ttl'       =>  $this->ttl,
-            'data'      =>  $this->jsonData
+            'data'      =>  $this->jsonData,
         ];
-        if (!empty($this->channelId)) {
+        if (! empty($this->channelId)) {
             $message['channelId'] = $this->channelId;
         }
+
         return $message;
     }
 }

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -47,7 +47,7 @@ class ExpoMessage
      *
      * @var string
      */
-    protected $channelId = 'Default';
+    protected $channelId = '';
 
     /**
      * The json data attached to the message.
@@ -205,14 +205,17 @@ class ExpoMessage
      */
     public function toArray()
     {
-        return [
+        $message = [
             'title'     =>  $this->title,
             'body'      =>  $this->body,
             'sound'     =>  $this->sound,
             'badge'     =>  $this->badge,
             'ttl'       =>  $this->ttl,
-            'channelId' =>  $this->channelId,
-            'data'      => $this->jsonData,
+            'data'      =>  $this->jsonData
         ];
+        if (!empty($this->channelId)) {
+            $message['channelId'] = $this->channelId;
+        }
+        return $message;
     }
 }


### PR DESCRIPTION
There is a bug where the notifications aren't received in Android devices when the property "channelId" is sent.

So this property should be totally optional