### PR TITLE
Debug option is now configurable.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "alymosul/laravel-exponent-push-notifications",
+    "name": "codificio/laravel-exponent-push-notifications",
     "description": "Exponent push notifications driver for laravel",
     "homepage": "https://github.com/alymosul/laravel-exponent-push-notifications",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "codificio/laravel-exponent-push-notifications",
+    "name": "alymosul/laravel-exponent-push-notifications",
     "description": "Exponent push notifications driver for laravel",
     "homepage": "https://github.com/alymosul/laravel-exponent-push-notifications",
     "license": "MIT",

--- a/config/exponent-push-notifications.php
+++ b/config/exponent-push-notifications.php
@@ -7,6 +7,8 @@
  */
 
 return [
+    'debug' => env('EXPONENT_PUSH_NOTIFICATION_DEBUG', false),
+
     'interests' => [
         'driver' => env('EXPONENT_PUSH_NOTIFICATION_INTERESTS_STORAGE_DRIVER', 'file'),
 

--- a/config/exponent-push-notifications.php
+++ b/config/exponent-push-notifications.php
@@ -7,7 +7,7 @@
  */
 
 return [
-    'debug' => env('EXPONENT_PUSH_NOTIFICATION_DEBUG', false),
+    'debug' => env('EXPONENT_PUSH_NOTIFICATION_DEBUG', true),
 
     'interests' => [
         'driver' => env('EXPONENT_PUSH_NOTIFICATION_INTERESTS_STORAGE_DRIVER', 'file'),

--- a/src/ExpoChannel.php
+++ b/src/ExpoChannel.php
@@ -52,7 +52,7 @@ class ExpoChannel
             $this->expo->notify(
                 $interest,
                 $notification->toExpoPush($notifiable)->toArray(),
-                true
+                config('exponent-push-notifications.debug')
             );
         } catch (ExpoException $e) {
             $this->events->dispatch(


### PR DESCRIPTION
With `debug` option always true, `ExpoException` in `ExpoChannel.php` is never thrown.