### PR TITLE
disable autoinctement for Interest model

### DIFF
--- a/src/Models/Interest.php
+++ b/src/Models/Interest.php
@@ -25,6 +25,9 @@ class Interest extends Model
      *
      * @var array
      */
+
+    public $incrementing = false;
+
     protected $fillable = [
         'key',
         'value',


### PR DESCRIPTION
If you use a database driver, we have an exception: the "id" column does not exist. To fix this, you need to disable auto-increment in model.