### PR TITLE
Update exponent-server-sdk-php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.1.3|^8.0",
-        "alymosul/exponent-server-sdk-php": "1.1.*",
+        "alymosul/exponent-server-sdk-php": "1.3.*",
         "laravel/framework": "^5.6 | ^6.0 | ^7.0 | ^8.0"
     },
     "require-dev": {

--- a/src/ExpoChannel.php
+++ b/src/ExpoChannel.php
@@ -48,9 +48,11 @@ class ExpoChannel
         $interest = $notifiable->routeNotificationFor('ExpoPushNotifications')
             ?: $this->interestName($notifiable);
 
+        $interests = [ $interest ];
+
         try {
             $this->expo->notify(
-                $interest,
+                $interests,
                 $notification->toExpoPush($notifiable)->toArray(),
                 config('exponent-push-notifications.debug')
             );

--- a/src/ExpoChannel.php
+++ b/src/ExpoChannel.php
@@ -48,7 +48,7 @@ class ExpoChannel
         $interest = $notifiable->routeNotificationFor('ExpoPushNotifications')
             ?: $this->interestName($notifiable);
 
-        $interests = [ $interest ];
+        $interests = [$interest];
 
         try {
             $this->expo->notify(

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -68,7 +68,7 @@ class ChannelTest extends TestCase
 
         $data = $message->toArray();
 
-        $this->expo->shouldReceive('notify')->with('interest_name', $data, true)->andReturn([['status' => 'ok']]);
+        $this->expo->shouldReceive('notify')->with(['interest_name'], $data, true)->andReturn([['status' => 'ok']]);
 
         $this->channel->send($this->notifiable, $this->notification);
     }
@@ -80,7 +80,7 @@ class ChannelTest extends TestCase
 
         $data = $message->toArray();
 
-        $this->expo->shouldReceive('notify')->with('interest_name', $data, true)->andThrow(ExpoException::class, '');
+        $this->expo->shouldReceive('notify')->with(['interest_name'], $data, true)->andThrow(ExpoException::class, '');
 
         $this->events->shouldReceive('dispatch')->with(Mockery::type(NotificationFailed::class));
 


### PR DESCRIPTION
Update exponent-server-sdk-php version.
Version include some improvements, such as processing API error response with empty body.