### PR TITLE
Missing changes for laravel 9

### DIFF
--- a/src/Http/ExpoController.php
+++ b/src/Http/ExpoController.php
@@ -39,7 +39,7 @@ class ExpoController extends Controller
         ]);
 
         if ($validator->fails()) {
-            return JsonResponse::create([
+            return new JsonResponse([
                 'status' => 'failed',
                 'error' => [
                     'message' => 'Expo Token is required',
@@ -54,7 +54,7 @@ class ExpoController extends Controller
         try {
             $this->expoChannel->expo->subscribe($interest, $token);
         } catch (\Exception $e) {
-            return JsonResponse::create([
+            return new JsonResponse([
                 'status'    => 'failed',
                 'error'     =>  [
                     'message' => $e->getMessage(),
@@ -62,7 +62,7 @@ class ExpoController extends Controller
             ], 500);
         }
 
-        return JsonResponse::create([
+        return new JsonResponse([
             'status'    =>  'succeeded',
             'expo_token' => $token,
         ], 200);
@@ -83,7 +83,7 @@ class ExpoController extends Controller
         ]);
 
         if ($validator->fails()) {
-            return JsonResponse::create([
+            return new JsonResponse([
                 'status' => 'failed',
                 'error' => [
                     'message' => 'Expo Token is invalid',
@@ -96,7 +96,7 @@ class ExpoController extends Controller
         try {
             $deleted = $this->expoChannel->expo->unsubscribe($interest, $token);
         } catch (\Exception $e) {
-            return JsonResponse::create([
+            return new JsonResponse([
                 'status'    => 'failed',
                 'error'     =>  [
                     'message' => $e->getMessage(),
@@ -104,6 +104,6 @@ class ExpoController extends Controller
             ], 500);
         }
 
-        return JsonResponse::create(['deleted' => $deleted]);
+        return new JsonResponse(['deleted' => $deleted]);
     }
 }

--- a/src/Models/Interest.php
+++ b/src/Models/Interest.php
@@ -38,6 +38,11 @@ class Interest extends Model
     public $timestamps = false;
 
     /**
+     * Table doesn't have an incrementing ID
+     */
+    public $incrementing = false;
+
+    /**
      * Interest constructor.
      *
      * @param  array  $attributes


### PR DESCRIPTION
Hi!,
I tried to use this package in laravel 9 as composer.json allows it but there were some missing points:

- Illuminate\Http\JsonResponse no longer has create method
- Interest model doesn't have a primary key so it cannot be created with firstOrCreate method

With this changes I was able to use the package I hope you can merge this changes or implement you own based on this.