### PR TITLE
Send notifications to multiple interests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 composer.phar
 composer.lock
 .idea
+.phpunit.result.cache

--- a/src/ExpoChannel.php
+++ b/src/ExpoChannel.php
@@ -7,6 +7,7 @@ use ExponentPhpSDK\Expo;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Arr;
 use NotificationChannels\ExpoPushNotifications\Exceptions\CouldNotSendNotification;
 
 class ExpoChannel
@@ -47,7 +48,7 @@ class ExpoChannel
         $interest = $notifiable->routeNotificationFor('ExpoPushNotifications')
             ?: $this->interestName($notifiable);
 
-        $interests = [$interest];
+        $interests = Arr::wrap($interest);
 
         try {
             $this->expo->notify(

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -74,6 +74,24 @@ class ChannelTest extends TestCase
     }
 
     /** @test */
+    public function itCanSendANNotificationToMultipleInterests()
+    {
+        $this->notifiable = Mockery::mock($this->notifiable);
+
+        $this->notifiable->shouldReceive('routeNotificationFor')
+            ->with('ExpoPushNotifications')
+            ->andReturn($interests = ['interest_1', 'interest_2']);
+
+        $message = $this->notification->toExpoPush($this->notifiable);
+
+        $data = $message->toArray();
+
+        $this->expo->shouldReceive('notify')->with($interests, $data, true)->andReturn([['status' => 'ok']]);
+
+        $this->channel->send($this->notifiable, $this->notification);
+    }
+
+    /** @test */
     public function itFiresFailureEventOnFailure()
     {
         $message = $this->notification->toExpoPush($this->notifiable);


### PR DESCRIPTION
The `alymosul/exponent-server-sdk-php` package supports sending a notification to multiple interests, however, this package forces you to only return one interest using the `routeNotificationForExpoPushNotifications()` method. I've changed this so that the developer can choose themselves if they want to return multiple interests or not. For me this is particularly useful because I've made a team notifiable and in the team `routeNotificationForExpoPushNotifications()` I can now return all intersets of users in that team.

## Small suggestion
I personally would maybe change the way the `routeNotificationForExpoPushNotifications()` method works. Instead of returning interests, I maybe would allow developers to return actual tokens. This optionally gives them more flexibility to decide which token needs to be used when sending notifications to a notifiable model. If no `routeNotificationForExpoPushNotifications()` exists, you obviously would keep the current implementation. This would mean that the `Expo` class also need to change. Maybe a `$expo->notifyDirectly(array $recipients, array $data, bool $debug);`

The `notify()` method itself could use that method as well:

```php
if (count($interests) == 0) {
    throw new ExpoException('Interests array must not be empty.');
}

// Gets the expo tokens for the interests
$recipients = $this->registrar->getInterests($interests);

return $this->notifyDirectly($recipients, $data, $debug);
```

Again, this would be useful for me. In my project I've my own API implementation for saving and managing tokens of a user because I need that to support multiple token types (Firebase and APN). Currently the package doesn't give me a lot of flexibility (which I get) and I need to override I few things in the service provider to accomplish this.

What do you think about this idea? I could make a PR as a proof of concept.