### PR TITLE
Report other exceptions to Error Handler.

### DIFF
--- a/src/ExpoChannel.php
+++ b/src/ExpoChannel.php
@@ -59,6 +59,8 @@ class ExpoChannel
             $this->events->dispatch(
                 new NotificationFailed($notifiable, $notification, 'expo-push-notifications', $e->getMessage())
             );
+        } catch (\Throwable $e) {
+            report($e);
         }
     }
 


### PR DESCRIPTION
[Laravel Error Handling](https://laravel.com/docs/8.x/errors) failed to catch other throwable exceptions such as UnexpectedResponseException. 
report() helper is use to report these exceptions via exception handler for customized handling.