### PR TITLE
Added notification prop to toExpoPush method

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ class AccountApproved extends Notification
         return [ExpoChannel::class];
     }
 
-    public function toExpoPush($notifiable)
+    public function toExpoPush($notifiable, $notification)
     {
         return ExpoMessage::create()
             ->badge(1)

--- a/src/ExpoChannel.php
+++ b/src/ExpoChannel.php
@@ -52,7 +52,7 @@ class ExpoChannel
         try {
             $this->expo->notify(
                 $interests,
-                $notification->toExpoPush($notifiable)->toArray(),
+                $notification->toExpoPush($notifiable, $notification)->toArray(),
                 config('exponent-push-notifications.debug')
             );
         } catch (ExpoException $e) {

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -64,7 +64,7 @@ class ChannelTest extends TestCase
     /** @test */
     public function itCanSendANotification()
     {
-        $message = $this->notification->toExpoPush($this->notifiable);
+        $message = $this->notification->toExpoPush($this->notifiable, $this->notification);
 
         $data = $message->toArray();
 
@@ -76,7 +76,7 @@ class ChannelTest extends TestCase
     /** @test */
     public function itFiresFailureEventOnFailure()
     {
-        $message = $this->notification->toExpoPush($this->notifiable);
+        $message = $this->notification->toExpoPush($this->notifiable, $this->notification);
 
         $data = $message->toArray();
 
@@ -105,7 +105,7 @@ class TestNotifiable
 
 class TestNotification extends Notification
 {
-    public function toExpoPush($notifiable)
+    public function toExpoPush($notifiable, $notification)
     {
         return new ExpoMessage();
     }


### PR DESCRIPTION
This pull request will add the ability to access the notification variable within the toExpoPush method, to avoid the error in [this issue](https://github.com/Alymosul/laravel-exponent-push-notifications/issues/90)